### PR TITLE
fix/ean-codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.2.7 - delivery @08/10/2020
+
+- fix Ean codes so they are built from right to left and not the opposite
+
 ## 1.2.6 - delivery @07/10/2020
 
 - update debugger

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,6 @@
 # TODO
 
+- add QR code support;
 - improve test coverage on barcodes generation;
 - make a browser version;
 - some font size ratios seem wrong and need to be verify.

--- a/lib/Barcode/Ean.js
+++ b/lib/Barcode/Ean.js
@@ -41,10 +41,13 @@ const generate = function generate(data, type) {
   const dataLength = data.length;
 
   // check each digit is numeric and construct the data to compute
-  let sum = 0;
-  let odd = false;
+  let checksum = 0;
+  let odd = true;
 
-  for (let i = 0; i < dataLength; i += 1) {
+  // starting from the end of data as position 1 whatever the code length is
+  // ean odd data digits are always weight of 3
+  // ean even data digits are always weight of 1
+  for (let i = dataLength - 1; i >= 0; i -= 1) {
     const intChar = int(data.charAt(i));
 
     if (intChar === undefined) {
@@ -54,11 +57,11 @@ const generate = function generate(data, type) {
       throw error;
     }
 
-    sum += (odd ? 1 : 3) * intChar;
+    checksum += (odd ? 3 : 1) * intChar;
     odd = !odd;
   }
 
-  const dataToEncode = `${data}${(10 - (sum % 10)) % 10}`;
+  const dataToEncode = `${data}${(10 - (checksum % 10)) % 10}`;
 
   // start
   let digit = '101';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitgener",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "A lightweight and zero-dependencies pure Node.js barcode generator",
   "author": "Adrien Valcke <adrienvalcke@icloud.com> (https://github.com/adrienv1520)",
   "main": "lib/index.js",


### PR DESCRIPTION
#### What does this PR contain?

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**
- [ ] **dependency update**
- [ ] **documentation update**

#### Motivation / Use-Case

Ean codes should have been built from right to left and not the opposite which made ean13 encoding wrong. Changing the odd value made ean13 working fine but ean8 was having errors. Changing the algorithm resolved the issue.

#### Breaking Changes

/

#### Release Notes

- fix Ean codes so they are built from right to left and not the opposite
